### PR TITLE
fix typo in set_schedule

### DIFF
--- a/simanneal/anneal.py
+++ b/simanneal/anneal.py
@@ -43,7 +43,7 @@ class Annealer(object):
         """Takes the output from `auto` and sets the attributes
         """
         self.Tmax = schedule['tmax']
-        self.Tmax = schedule['tmin']
+        self.Tmin = schedule['tmin']
         self.steps = int(schedule['steps'])
 
     def copy_state(self, state):


### PR DESCRIPTION
Fix self.Tmin = schedule['tmax'] in set_schedule, probably caused by copy paste.
