### PR TITLE
Change the date format in the state filename & support state variable of type numpy.ndarray

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.pyc
 *.egg-info
 dist/*
+*.state

--- a/simanneal/anneal.py
+++ b/simanneal/anneal.py
@@ -43,7 +43,7 @@ class Annealer(object):
     save_state_on_exit = True
 
     def __init__(self, initial_state=None, load_state=None):
-        if initial_state:
+        if len(initial_state) > 0:
             self.state = self.copy_state(initial_state)
         elif load_state:
             with open(load_state, 'rb') as fh:

--- a/simanneal/anneal.py
+++ b/simanneal/anneal.py
@@ -57,7 +57,7 @@ class Annealer(object):
     def save_state(self, fname=None):
         """Saves state"""
         if not fname:
-            date = datetime.datetime.now().isoformat().split(".")[0]
+            date = datetime.datetime.now().strftime("%Y-%m-%dT%Hh%Mm%Ss")
             fname = date + "_energy_" + str(self.energy()) + ".state"
         print("Saving state to: %s" % fname)
         with open(fname, "w") as fh:


### PR DESCRIPTION
  - Windows doesn't accept colons in the filenames, and couldn't create the state file.

Here is the error I'm getting when I run the `salesman.py` example:

```sh
File "c:\github\simanneal\simanneal\anneal.py", line 63, in save_state
    with open(fname, "w") as fh:
IOError: [Errno 22] invalid mode ('w') or filename: u'2016-06-23T01:13:58_energy_7060.97080007.state'
```

  - The second error concerns the case when a `numpy.ndarray` variable is used as a state variable, and is shown below:

```sh
File "c:\github\simanneal\simanneal\anneal.py", line 46, in __init__
    if initial_state:
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```