### PR TITLE
Allow optimizing per-move energy changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,13 @@ them into the constructor like so
 
 The last line (calling init on the super class) is critical. 
 
+## Optimizations
+
+For some problems the `energy` function is prohibitively expensive to calculate
+after every move. It is often possible to compute the change in energy that a
+move causes much more efficiently. A delta value can be returned from `move` to
+update the energy value without calling `energy` multiple times.
+
 ## Implementation Details
 
 The simulated annealing algorithm requires that we track state (current, previous, best) and thus means we need to copy the `self.state` frequently.

--- a/simanneal/anneal.py
+++ b/simanneal/anneal.py
@@ -193,9 +193,12 @@ class Annealer(object):
         while step < self.steps and not self.user_exit:
             step += 1
             T = self.Tmax * math.exp(Tfactor * step / self.steps)
-            self.move()
-            E = self.energy()
-            dE = E - prevEnergy
+            dE = self.move()
+            if dE is None:
+                E = self.energy()
+                dE = E - prevEnergy
+            else:
+                E += dE
             trials += 1
             if dE > 0.0 and math.exp(-dE / T) < random.random():
                 # Restore previous state


### PR DESCRIPTION
I have looked through some closed issues, and optimization is not necessarily a goal of this library, but while I was prototyping solution for a problem I found it very useful to be able to compute energy deltas during a move in O(n^2) time rather than running the full energy function in O(n^4) time. I needed to verify that the partial calculation was possible before investing the time in a native implementation.