### PR TITLE
Avoid copies if it is possible to undo a move

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,20 @@ them into the constructor like so
 
 The last line (calling `__init__` on the super class) is critical.
 
+## Implementation Details
+
+The simulated annealing algorithm requires that we track states (current, previous, best), which means we need to copy `self.state` frequently.
+
+Copying an object in Python is not always straightforward or performant. The standard library provides a `copy.deepcopy()` method to copy arbitrary python objects but it is very expensive. Certain objects can be copied by more efficient means: lists can be sliced and dictionaries can use their own .copy method, etc.
+
+In order to facilitate flexibility, you can specify the `copy_strategy` attribute
+which defines one of:
+* `deepcopy`: uses `copy.deepcopy(object)`
+* `slice`: uses `object[:]`
+* `method`: uses `object.copy()`
+
+If you want to implement your own custom copy mechanism, override the `copy_state` method.
+
 ## Optimizations
 
 For some problems the `energy` function is prohibitively expensive to calculate
@@ -149,19 +163,12 @@ energy from the previous state, this approach will save you a call to
 value and sometimes return `None`, depending on the type of modification it
 makes to the state and the complexity of calculting a delta.
 
-## Implementation Details
-
-The simulated annealing algorithm requires that we track states (current, previous, best), which means we need to copy `self.state` frequently.
-
-Copying an object in Python is not always straightforward or performant. The standard library provides a `copy.deepcopy()` method to copy arbitrary python objects but it is very expensive. Certain objects can be copied by more efficient means: lists can be sliced and dictionaries can use their own .copy method, etc.
-
-In order to facilitate flexibility, you can specify the `copy_strategy` attribute
-which defines one of:
-* `deepcopy`: uses `copy.deepcopy(object)`
-* `slice`: uses `object[:]`
-* `method`: uses `object.copy()`
-
-If you want to implement your own custom copy mechanism, override the `copy_state` method.
+Another optimization relates to avoiding copying the state for every move; 
+for some problems it is possible to easily undo the last move. For
+such problems your class can implement an `undo_move(self)` method, which changes
+`self.state` back to the state it was in before the last `move(self)` method call. 
+Using this method almost all the copying can be avoided, which may significantly 
+speed up the annealing process if the copies themselves take a lot of time.
 
 ## Notes
 


### PR DESCRIPTION
For states with complex objects, copies can take a significant bulk of the time spent by the algorithm. This pull requests add optional support for defining `def undo_move(self)` method on the class, which the user can implement to undo the last move, almost avoiding the copying in the body of the annealing.

For demonstration purposes consider the following (admittedly convoluted) example:
```python
import random
from simanneal import Annealer

class Queen:
    def __init__(self, row):
        self.row = row
        self.dummy1 = set(range(12))
        self.dummy2 = {i:i for i in range(15)}
        self.dummy3 = {i:i for i in range(20)}


class NQueensProblem(Annealer):
    def move(self):
        """Move a queen on a random column to some different row."""
        column = random.randrange(len(self.state))
        new_row = random.randrange(len(self.state))

        self.last_move = (column, self.state[column].row)
        self.state[column].row = new_row

    def undo_move(self):
        self.state[self.last_move[0]].row = self.last_move[1]

    def energy(self):
        """Calculates the number of attacks among the queens."""
        e = 0
        for i in range(len(self.state)):
            for j in range(i + 1, len(self.state)):
                e += self.state[i].row == self.state[j].row
                e += abs(i - j) == abs(self.state[i].row - self.state[j].row)
        return e


if __name__ == '__main__':
    nqueens = NQueensProblem([Queen(row) for row in range(20)])
    nqueens.Tmax = 100
    nqueens.Tmin = 0.1
    nqueens.steps = 500000
    state, e = nqueens.anneal()

    print()
    print(f"number of attacks: {e}")
    print([s.row for s in state])
```

On my pc, this code runs approximately 20x slower when I comment out `undo_move` (3 minutes vs 10 seconds).